### PR TITLE
Allow support for 12.1.x-cpu-ml-scala2.12 runtime

### DIFF
--- a/Includes/_common.py
+++ b/Includes/_common.py
@@ -17,8 +17,8 @@ course_config = CourseConfig(course_code = "sml",
                              install_min_time = "2 min",
                              install_max_time = "5 min",
                              remote_files = remote_files,
-                             supported_dbrs = ["11.3.x-cpu-ml-scala2.12"],
-                             expected_dbrs = "11.3.x-cpu-ml-scala2.12")
+                             supported_dbrs = ["11.3.x-cpu-ml-scala2.12", "12.1.x-cpu-ml-scala2.12"],
+                             expected_dbrs = "11.3.x-cpu-ml-scala2.12, 12.1.x-cpu-ml-scala2.12")
 
 lesson_config = LessonConfig(name = None,
                              create_schema = True,

--- a/Solutions/Includes/_common.py
+++ b/Solutions/Includes/_common.py
@@ -17,8 +17,8 @@ course_config = CourseConfig(course_code = "sml",
                              install_min_time = "2 min",
                              install_max_time = "5 min",
                              remote_files = remote_files,
-                             supported_dbrs = ["11.3.x-cpu-ml-scala2.12"],
-                             expected_dbrs = "11.3.x-cpu-ml-scala2.12")
+                             supported_dbrs = ["11.3.x-cpu-ml-scala2.12", "12.1.x-cpu-ml-scala2.12"],
+                             expected_dbrs = "11.3.x-cpu-ml-scala2.12, 12.1.x-cpu-ml-scala2.12")
 
 lesson_config = LessonConfig(name = None,
                              create_schema = True,


### PR DESCRIPTION
I ran all the notebooks against Databricks runtime 12.1.x-cpu-ml-scala2.12 with no problems.